### PR TITLE
The promise filterFileContent sometimes resolved too soon

### DIFF
--- a/lib/filematcher.ts
+++ b/lib/filematcher.ts
@@ -225,9 +225,6 @@ export class FileMatcher extends EventEmitter {
                   // Call endFileSearch only when all items are done.
                   self.endFileSearch(dir);
                   resolve();
-                }).catch(err => {
-                  self.endFileSearch(dir);
-                  reject(err);
                 });
             });
         });
@@ -255,8 +252,7 @@ export class FileMatcher extends EventEmitter {
 
                     // This item is done only when the directory is done
                     this.readDirectory(item)
-                        .then(() => resolve())
-                        .catch(err => reject(err));
+                        .then(() => resolve());
                 } else {
                   resolve();
                 }


### PR DESCRIPTION
While working on making the matching cancelable, I found a small bug in the filterFileContent function. Originally, the function creates promise for every file, and resolves when the last index was digests. 

The problem is that because promises are asynchronic, the last file can be digested before some of the files. In that case, the returned result doesn't contain the right files. The solution is to use Promise.all. (This issue is reproducible by running the test `Should filter by content only` enough times on slow enough disk).

I also changed the function to resolve even if some of the files failed. It believe that the search shouldn't fail completely if one or two files are not readable by the user.